### PR TITLE
Migrate custom-urls from PHPCR to Sulu 3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,223 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**SuluPHPCRMigrationBundle** is a Symfony bundle that migrates Sulu CMS content from PHPCR (v2.6) to the new SuluContentBundle database structure (v3.0). It handles pages, snippets, and articles with full localization support.
+
+## Development Commands
+
+Use Symfony composer script commands (defined in composer.json):
+
+```bash
+# Testing & Quality
+composer test           # Run all tests (PHPUnit)
+composer phpunit        # Run tests only
+composer lint           # Run all linters (PHPStan, PHP-CS-Fixer, Rector, Deptrac)
+composer fix            # Auto-fix code style issues
+
+# Individual Quality Tools
+composer phpstan        # Static analysis (level: max)
+composer php-cs         # Check code style (dry-run)
+composer php-cs-fix     # Fix code style
+composer rector         # Apply automated refactoring
+composer lint-rector    # Check rector rules (dry-run)
+composer deptrac        # Check architectural dependencies
+```
+
+**Runtime Commands**:
+```bash
+php bin/adminconsole phpcr:migrations:migrate           # Prepare PHPCR structure
+php bin/adminconsole sulu:phpcr-migration:migrate       # Run full migration
+php bin/adminconsole sulu:phpcr-migration:migrate page  # Migrate specific type (page|snippet|article|custom_url)
+```
+
+## Architecture Overview
+
+This bundle follows **Clean Architecture** principles enforced by Deptrac:
+
+```
+PhpcrMigration/
+├── UserInterface/       → Entry points (Console commands)
+├── Application/         → Business logic & use cases
+│   ├── Parser/         → Parse PHPCR nodes to arrays
+│   ├── Persister/      → Persist to new storage
+│   ├── Session/        → PHPCR session management
+│   ├── Repository/     → Data access abstraction
+│   └── Exception/      → Domain exceptions
+└── Infrastructure/      → External implementations
+```
+
+**Dependency Rules** (from deptrac.yaml):
+- UserInterface → Application
+- Infrastructure → Application
+- Application → Domain (when Domain layer exists)
+- No reverse dependencies allowed
+
+### Key Design Patterns
+
+1. **Chain of Responsibility** (Parsers):
+   - `ChainNodeParser` orchestrates multiple parsers
+   - Each parser (`PageNodeParser`, `ArticleNodeParser`, etc.) handles specific logic
+   - Parsers registered via Symfony service tags: `sulu_phpcr_migration.node_parser`
+
+2. **Strategy Pattern** (Persisters):
+   - `PersisterPool` selects appropriate persister by content type
+   - Each persister (`PagePersister`, `SnippetPersister`, `ArticlePersister`) implements type-specific logic
+   - Persisters registered via service tags: `sulu_phpcr_migration.persister`
+
+3. **Repository Pattern**:
+   - `EntityRepository` provides abstraction over Doctrine with entity caching
+   - Implements `EntityRepositoryInterface` for testability
+
+### Service Configuration
+
+- **Format**: XML (not YAML) - see `Resources/config/*.xml`
+- **Service Prefix**: `sulu_phpcr_migration.*`
+- **Extension Pattern**: Tagged iterator for parsers and persisters
+- **Dependency Injection**: Constructor injection exclusively
+
+## Code Conventions
+
+### PHP Standards
+
+- **PHP Version**: 8.1+ (supports up to 8.4)
+- **Strict Types**: Required in all files (`declare(strict_types=1);`)
+- **Type Hints**: Full type hints on all parameters and return types
+- **Array Shapes**: Use PHPStan docblocks for complex array structures
+- **Modern PHP**: Use readonly properties, constructor property promotion, attributes where appropriate
+
+### Quality Requirements
+
+- **PHPStan Level**: max (strictest level)
+- **Code Style**: @Symfony standard via PHP-CS-Fixer
+- **License Header**: MIT license required in all files
+- **Architecture**: Deptrac validates layer dependencies - do not violate defined rules
+
+### PHPCR-Specific Patterns
+
+**Property Parsing**:
+- Localized properties use `i18n-{locale}` prefix (e.g., `i18n-en-title`)
+- Block properties require length trimming via `PropertyParser::trimBlocksToLengths()`
+- Nested blocks (block within block) require special handling
+- Image maps use property path resolution
+- Excerpt properties use `excerpt-` prefix (e.g., `i18n-en-excerpt-title`)
+- Segments stored as separate PHPCR properties per webspace (e.g., `i18n-en-excerpt-segments-sulu_io`, `i18n-en-excerpt-segments-blog`) and reconstructed into a map structure by the parser
+
+**Block ID Migration**:
+- Migrated blocks automatically receive unique IDs during persistence
+- Block IDs are 8-character hexadecimal strings (e.g., `a1b2c3d4`)
+- Generated using xxHash 32-bit algorithm with microsecond-precision timestamps
+- IDs added recursively to all block structures in templateData
+- Preserves existing IDs if already present (idempotent operation)
+- Block detection: numerically indexed arrays where elements have `'type'` key
+- Handles nested blocks (blocks within blocks) automatically
+
+**Excerpt Tab Migration**:
+- **Categories & Tags**: Migrated as many-to-many relations via junction tables
+- **Audience Targeting Groups**: Migrated as many-to-many relations (similar to categories/tags)
+- **Segments**:
+  - PHPCR storage: Separate properties per webspace (`excerpt-segments-{webspace}`)
+  - Parser reconstruction: `["webspace_key" => "segment_value"]` map
+  - Sulu 3.0 target: Single VARCHAR column storing one segment value
+  - Transformation logic:
+    - Pages: Extract segment value for the page's webspace
+    - Articles/Snippets: Use first segment value from the map
+- **Images & Icons**: Media selection fields migrated as foreign keys
+
+**CustomUrl Migration**:
+- **PHPCR Structure**: CustomUrl documents with embedded routes as child nodes
+- **Sulu 3.0 Structure**: Two separate tables (`cu_custom_url` and `cu_custom_url_route`)
+- **Key Changes**:
+  - CustomUrl now has explicit `webspace` field (extracted from PHPCR path `/cmf/<webspace>/custom-urls/`)
+  - Routes stored in separate table with foreign key relationship
+  - Self-referencing `target_route_uuid` enables history route chains for 301 redirects
+  - Published state determines visibility (no draft/live stages like pages)
+- **Properties Migrated**:
+  - Main entity: uuid, title, published, baseDomain, webspace, domainParts (JSON)
+  - Target reference: targetDocument (page UUID), targetLocale
+  - SEO properties: canonical, redirect, noFollow, noIndex
+  - Routes: uuid, path, history flag (in separate table)
+- **Route Handling**: PHPCR child nodes (`routes/*`) migrated to `cu_custom_url_route` records
+
+**Query Strategy**:
+- Use SQL2 queries to fetch nodes by mixin type
+- Sort by path depth first, then `sulu:order` to ensure parent-child processing order
+- Example: `SELECT * FROM [sulu:page] ORDER BY depth, [sulu:order]`
+
+**Session Management**:
+- Dual workspace support: `default` and `live`
+- DSN formats: `dbal://` (Doctrine DBAL) or `jackrabbit://` (Jackrabbit)
+- Access via `SessionManager` interface
+
+## Testing
+
+**Test Structure**:
+- Unit tests: `Tests/Unit/`
+- Functional tests: `Tests/Functional/`
+- Test application: `Tests/Application/`
+
+**Test Execution**:
+```bash
+composer phpunit                    # All tests
+vendor/bin/phpunit --testsuite=Unit # Unit tests only
+```
+
+**CI Environment**:
+- Tests run on PHP 8.1, 8.2, 8.3, 8.4
+- Matrix includes lowest and highest dependency versions
+- MySQL 8.0 required for functional tests
+
+## Common Development Patterns
+
+### Adding a New Parser
+
+1. Create parser class implementing `NodeParserInterface` in `Application/Parser/`
+2. Extend `PropertyNodeParser` for property parsing utilities
+3. Register service with tag `sulu_phpcr_migration.node_parser` in `Resources/config/parser.xml`
+4. Implement `supports(Node $node): bool` to define node type handling
+5. Implement `parse(Node $node): array` with proper array shape docblock
+
+### Adding a New Persister
+
+1. Create persister class extending `AbstractPersister` in `Application/Persister/`
+2. Register service with tag `sulu_phpcr_migration.persister` in `Resources/config/persister.xml`
+3. Tag must include `type` attribute (e.g., `type="page"`)
+4. Implement `doPersist(string $locale, array $data): void` for persistence logic
+5. Use `$this->entityRepository` for data access
+6. Implement abstract methods for excerpt junction table names:
+   - `getDimensionContentExcerptCategoriesTableName()` / `getDimensionContentExcerptCategoriesIdName()`
+   - `getDimensionContentExcerptTagsTableName()` / `getDimensionContentExcerptTagsIdName()`
+   - `getDimensionContentExcerptAudienceTargetGroupsTableName()` / `getDimensionContentExcerptAudienceTargetGroupsIdName()`
+
+**Junction Table Naming Pattern**: `{prefix}_{type}_dimension_content_excerpt_{relation}`
+- Pages: `pa_page_dimension_content_excerpt_categories`
+- Articles: `ar_article_dimension_content_excerpt_audience_target_groups`
+- Snippets: `sn_snippet_dimension_content_excerpt_tags`
+
+### Handling New PHPCR Property Types
+
+1. Add parsing logic to appropriate parser (or create new one)
+2. Use `PropertyParser::trimBlocksToLengths()` for block properties
+3. For nested structures, check `PropertyParser::parseProperty()` implementation
+4. Add test cases covering the new property structure
+
+## Important Implementation Notes
+
+**Migration Safety**:
+- Migrations are idempotent and can be re-run safely
+- Content is overwritten, not duplicated
+- Supports selective migration by document type
+- Always test migrations on non-production data first
+
+**Symfony Integration**:
+- Bundle class: `SuluPhpcrMigrationBundle`
+- No extension class needed (uses default)
+- Services auto-configured via XML
+- Compatible with Symfony 6.0 and 7.0
+
+**Dependencies**:
+- Requires both Jackalope implementations (doctrine-dbal and jackrabbit)
+- Uses Doctrine DBAL for entity persistence
+- Symfony Console for command interface

--- a/PhpcrMigration/Application/Parser/CustomUrlNodeParser.php
+++ b/PhpcrMigration/Application/Parser/CustomUrlNodeParser.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Parser;
+
+use PHPCR\NodeInterface;
+
+/**
+ * Parses PHPCR CustomUrl nodes to array structure for Sulu 3.0 migration.
+ */
+class CustomUrlNodeParser implements NodeParserInterface
+{
+    public function __construct(
+        private readonly PropertyNodeParser $propertyNodeParser,
+    ) {
+    }
+
+    public function supports(NodeInterface $node): bool
+    {
+        foreach ($node->getMixinNodeTypes() as $mixinNodeType) {
+            if ('sulu:custom_url' === $mixinNodeType->getName()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{}|array{
+     *     uuid: string,
+     *     title: string,
+     *     published: bool,
+     *     baseDomain: string,
+     *     webspace: string,
+     *     domainParts: array<string>,
+     *     targetDocument: string|null,
+     *     targetLocale: string,
+     *     canonical: bool,
+     *     redirect: bool,
+     *     noFollow: bool,
+     *     noIndex: bool,
+     *     routes: array<int, array{uuid: string, path: string, history: bool}>,
+     *     created: \DateTimeInterface,
+     *     changed: \DateTimeInterface,
+     *     creator: int|null,
+     *     changer: int,
+     * }
+     */
+    public function parse(NodeInterface $node): array
+    {
+        if (!$this->supports($node)) {
+            return [];
+        }
+
+        // Parse base properties using PropertyNodeParser
+        $baseData = $this->propertyNodeParser->parse($node);
+
+        // Extract webspace from path (/cmf/<webspace>/custom-urls/...)
+        $path = $node->getPath();
+        $pathParts = \explode('/', $path);
+        $webspace = $pathParts[2] ?? '';
+
+        // Parse routes from child nodes
+        $routes = [];
+        if ($node->hasNode('routes')) {
+            $routesNode = $node->getNode('routes');
+            foreach ($routesNode->getNodes() as $routeNode) {
+                $uuidValue = $routeNode->getProperty('jcr:uuid')->getString();
+                $pathValue = $routeNode->getProperty('sulu:path')->getString();
+                $historyValue = $routeNode->hasProperty('sulu:history')
+                    ? $routeNode->getProperty('sulu:history')->getBoolean()
+                    : false;
+
+                $routes[] = [
+                    'uuid' => \is_array($uuidValue) ? $uuidValue[0] : $uuidValue,
+                    'path' => \is_array($pathValue) ? $pathValue[0] : $pathValue,
+                    'history' => \is_array($historyValue) ? (bool) $historyValue[0] : $historyValue,
+                ];
+            }
+        }
+
+        // Extract values with type assertions
+        /** @var array{uuid?: string} $jcrData */
+        $jcrData = $baseData['jcr'];
+        /** @var array{title?: string, published?: bool, baseDomain?: string, domainParts?: array<string>, targetDocument?: string, targetLocale?: string, canonical?: bool, redirect?: bool, noFollow?: bool, noIndex?: bool} $nullLocalization */
+        $nullLocalization = $baseData['localizations']['null'] ?? [];
+        /** @var array{created?: \DateTimeInterface, changed?: \DateTimeInterface, creator?: int, changer?: int} $suluData */
+        $suluData = $baseData['sulu'];
+
+        return [
+            'uuid' => $jcrData['uuid'] ?? '',
+            'title' => $nullLocalization['title'] ?? '',
+            'published' => $nullLocalization['published'] ?? false,
+            'baseDomain' => $nullLocalization['baseDomain'] ?? '',
+            'webspace' => $webspace,
+            'domainParts' => $nullLocalization['domainParts'] ?? [],
+            'targetDocument' => $nullLocalization['targetDocument'] ?? null,
+            'targetLocale' => $nullLocalization['targetLocale'] ?? 'en',
+            'canonical' => $nullLocalization['canonical'] ?? false,
+            'redirect' => $nullLocalization['redirect'] ?? false,
+            'noFollow' => $nullLocalization['noFollow'] ?? false,
+            'noIndex' => $nullLocalization['noIndex'] ?? false,
+            'routes' => $routes,
+            'created' => $suluData['created'] ?? new \DateTime(),
+            'changed' => $suluData['changed'] ?? new \DateTime(),
+            'creator' => $suluData['creator'] ?? null,
+            'changer' => $suluData['changer'] ?? 0,
+        ];
+    }
+}

--- a/PhpcrMigration/Application/Persister/AbstractPersister.php
+++ b/PhpcrMigration/Application/Persister/AbstractPersister.php
@@ -46,7 +46,6 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 abstract class AbstractPersister implements PersisterInterface
 {
-    // TODO this needs to be ro_routes after the legacy RouteBundle is removed
     public const ROUTE_TABLE = 'ro_routes';
 
     public const URL = '_url';

--- a/PhpcrMigration/Application/Persister/CustomUrlPersister.php
+++ b/PhpcrMigration/Application/Persister/CustomUrlPersister.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
+
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
+
+/**
+ * Persists CustomUrl data to Sulu 3.0 database structure.
+ *
+ * Handles migration of:
+ * - CustomUrl main entity (cu_custom_url table)
+ * - CustomUrlRoute entities (cu_custom_url_route table)
+ */
+class CustomUrlPersister implements PersisterInterface
+{
+    public function __construct(
+        private readonly EntityRepositoryInterface $entityRepository,
+    ) {
+    }
+
+    public function supports(array $document): bool
+    {
+        return isset($document['baseDomain']) && isset($document['domainParts']);
+    }
+
+    public static function getType(): string
+    {
+        return 'custom_url';
+    }
+
+    /**
+     * @param array{
+     *     uuid: string,
+     *     title: string,
+     *     published: bool,
+     *     baseDomain: string,
+     *     webspace: string,
+     *     domainParts: array<string>,
+     *     targetDocument: string|null,
+     *     targetLocale: string,
+     *     canonical: bool,
+     *     redirect: bool,
+     *     noFollow: bool,
+     *     noIndex: bool,
+     *     routes: array<int, array{uuid: string, path: string, history: bool}>,
+     *     created: \DateTimeInterface,
+     *     changed: \DateTimeInterface,
+     *     creator: int|null,
+     *     changer: int,
+     * } $document
+     */
+    public function persist(array $document, bool $isLive): void
+    {
+        // Insert or update CustomUrl entity
+        $customUrlData = [
+            'uuid' => $document['uuid'],
+            'title' => $document['title'],
+            'published' => $document['published'],
+            'baseDomain' => $document['baseDomain'],
+            'webspace' => $document['webspace'],
+            'domainParts' => $document['domainParts'],
+            'targetDocument' => $document['targetDocument'],
+            'targetLocale' => $document['targetLocale'],
+            'canonical' => $document['canonical'],
+            'redirect' => $document['redirect'],
+            'noFollow' => $document['noFollow'],
+            'noIndex' => $document['noIndex'],
+        ];
+
+        $this->entityRepository->insertOrUpdate(
+            $customUrlData,
+            'cu_custom_url',
+            [
+                'uuid' => 'string',
+                'title' => 'string',
+                'published' => 'boolean',
+                'baseDomain' => 'string',
+                'webspace' => 'string',
+                'domainParts' => 'json',
+                'targetDocument' => 'string',
+                'targetLocale' => 'string',
+                'canonical' => 'boolean',
+                'redirect' => 'boolean',
+                'noFollow' => 'boolean',
+                'noIndex' => 'boolean',
+            ],
+        );
+
+        // Remove existing routes for this custom URL
+        $this->entityRepository->removeBy(
+            'cu_custom_url_route',
+            ['customUrl' => $document['uuid']],
+        );
+
+        // Insert routes
+        foreach ($document['routes'] as $route) {
+            $routeData = [
+                'uuid' => $route['uuid'],
+                'customUrl' => $document['uuid'],
+                'path' => $route['path'],
+                'history' => $route['history'],
+                'target_route_uuid' => null, // Will be handled by Sulu 3.0 routing logic
+            ];
+
+            $this->entityRepository->insertOrUpdate(
+                $routeData,
+                'cu_custom_url_route',
+                [
+                    'uuid' => 'string',
+                    'customUrl' => 'string',
+                    'path' => 'string',
+                    'history' => 'boolean',
+                    'target_route_uuid' => 'string',
+                ],
+            );
+        }
+    }
+}

--- a/Resources/config/parser.xml
+++ b/Resources/config/parser.xml
@@ -23,6 +23,13 @@
             <tag name="sulu_phpcr_migration.node_parser"/>
         </service>
 
+        <service id="sulu_phpcr_migration.custom_url_parser"
+                 class="Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Parser\CustomUrlNodeParser">
+            <argument type="service" id="sulu_phpcr_migration.node_parser"/>
+
+            <tag name="sulu_phpcr_migration.node_parser"/>
+        </service>
+
         <service id="sulu_phpcr_migration.chain_node_parser"
                  class="Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Parser\ChainNodeParser">
 

--- a/Resources/config/persister.xml
+++ b/Resources/config/persister.xml
@@ -27,6 +27,13 @@
             <tag name="sulu_phpcr_migration.persister" type="article"/>
         </service>
 
+        <service id="sulu_phpcr_migration.custom_url_persister"
+                 class="Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister\CustomUrlPersister">
+            <argument type="service" id="sulu_phpcr_migration.entity_repository"/>
+
+            <tag name="sulu_phpcr_migration.persister" type="custom_url"/>
+        </service>
+
         <service id="sulu_phpcr_migration.persister_pool"
                  class="Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister\PersisterPool">
             <argument type="tagged_iterator" tag="sulu_phpcr_migration.persister" index-by="type"/>


### PR DESCRIPTION
Add CustomUrlNodeParser and CustomUrlPersister to migrate custom URLs from PHPCR (Sulu 2.6) to the new database structure (Sulu 3.0).

Changes:
- Add CustomUrlNodeParser: parses PHPCR custom_url nodes and routes
- Add CustomUrlPersister: persists to cu_custom_url and cu_custom_url_route tables
- Extract webspace from PHPCR path structure
- Handle route child nodes with history support
- Update CLAUDE.md with CustomUrl migration documentation