### PR TITLE
Use the correct string for the ROUTE_RESOUCE_KEY

### DIFF
--- a/PhpcrMigration/Application/Persister/AbstractPersister.php
+++ b/PhpcrMigration/Application/Persister/AbstractPersister.php
@@ -51,7 +51,7 @@ abstract class AbstractPersister implements PersisterInterface
 
     public const HISTORY_URLS = '_history_urls';
 
-    public const ROUTE_RESOURCE_KEY = 'route_history';
+    public const ROUTE_RESOURCE_KEY = 'route_histories';
 
     public function __construct(
         protected PropertyAccessorInterface $propertyAccessor,


### PR DESCRIPTION
Use the correct string for the ROUTE_RESOUCE_KEY, so that it matches that used in the Sulu 3.0 codebase.