### PR TITLE
Fix multiple mapping issues for the 3.0 tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,18 @@ PhpcrMigration/
 - Block detection: numerically indexed arrays where elements have `'type'` key
 - Handles nested blocks (blocks within blocks) automatically
 
-**Excerpt Tab Migration**:
-- **Categories & Tags**: Migrated as many-to-many relations via junction tables
-- **Audience Targeting Groups**: Migrated as many-to-many relations (similar to categories/tags)
+**SEO Data Migration** (Sulu 3.0):
+- **JSON Column**: `seoData` stores title, description, keywords, canonicalUrl
+- **Separate Columns**: `seoNoIndex`, `seoNoFollow`, `seoHideInSitemap` (booleans)
+- **Format**: `{"title": "...", "description": "...", "keywords": "...", "canonicalUrl": "..."}`
+- **Note**: Snippets do not have SEO data
+
+**Excerpt Tab Migration** (Sulu 3.0):
+- **JSON Column**: `excerptData` stores title, description, more, image, icon
+- **Format**: `{"title": "...", "description": "...", "more": "...", "image": {"id": 123}, "icon": {"id": 456}}`
+- **Separate Column**: `excerptSegment` (VARCHAR)
+- **Categories & Tags**: Migrated as many-to-many relations via junction tables (unchanged)
+- **Audience Targeting Groups**: Migrated as many-to-many relations (unchanged)
 - **Segments**:
   - PHPCR storage: Separate properties per webspace (`excerpt-segments-{webspace}`)
   - Parser reconstruction: `["webspace_key" => "segment_value"]` map
@@ -124,7 +133,6 @@ PhpcrMigration/
   - Transformation logic:
     - Pages: Extract segment value for the page's webspace
     - Articles/Snippets: Use first segment value from the map
-- **Images & Icons**: Media selection fields migrated as foreign keys
 
 **CustomUrl Migration**:
 - **PHPCR Structure**: CustomUrl documents with embedded routes as child nodes

--- a/PhpcrMigration/Application/Persister/AbstractPersister.php
+++ b/PhpcrMigration/Application/Persister/AbstractPersister.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
 
-use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\RoutePathNameNotFoundException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\UnsupportedDocumentTypeException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -69,23 +68,6 @@ abstract class AbstractPersister implements PersisterInterface
             throw new UnsupportedDocumentTypeException($document['jcr']['mixinTypes']);
         }
 
-        foreach ($document['localizations'] as $locale => $localizedData) {
-            if (
-                [] !== $localizedData
-                && isset($localizedData['routePath'])
-                && !isset($localizedData['routePathName'])
-            ) {
-                // fallback to 'routePath' when 'routePathName' is missing
-                $document['localizations'][$locale]['routePathName'] = 'routePath';
-            } elseif (
-                [] !== $localizedData
-                && !isset($localizedData['routePath'])
-                && !isset($localizedData['routePathName'])
-            ) {
-                throw new RoutePathNameNotFoundException($document['jcr']['uuid'], $locale);
-            }
-        }
-
         if ($this->isRoutable()) {
             $routes = $this->createOrUpdateRoutes($document);
             foreach ($routes as $locale => $route) {
@@ -137,49 +119,85 @@ abstract class AbstractPersister implements PersisterInterface
     }
 
     /**
-     * @param mixed[] $data
+     * Build the seoData JSON structure from localized data.
      *
-     * @return mixed[]
+     * @param array<string, mixed> $localizedData
+     *
+     * @return array<string, mixed>
      */
-    protected function mapExcerptImages(array $data): array
+    protected function buildSeoData(array $localizedData): array
     {
-        $value = $data['excerptImageId'] ?? null;
-        if (null === $value) {
-            return $data;
+        $seo = $localizedData['seo'] ?? [];
+        if (!\is_array($seo) || [] === $seo) {
+            return [];
         }
 
-        if (!\is_array($value)) {
-            unset($data['excerptImageId']);
-
-            return $data;
-        }
-
-        $data['excerptImageId'] = $data['excerptImageId']['ids'][0] ?? null;
-
-        return $data;
+        return \array_filter([
+            'title' => $seo['title'] ?? null,
+            'description' => $seo['description'] ?? null,
+            'keywords' => $seo['keywords'] ?? null,
+            'canonicalUrl' => $seo['canonicalUrl'] ?? null,
+        ], static fn ($value) => null !== $value);
     }
 
     /**
-     * @param mixed[] $data
+     * Build the excerptData JSON structure from localized data.
      *
-     * @return mixed[]
+     * @param array<string, mixed> $localizedData
+     *
+     * @return array<string, mixed>
      */
-    protected function mapExcerptIcons(array $data): array
+    protected function buildExcerptData(array $localizedData): array
     {
-        $value = $data['excerptIconId'] ?? null;
+        $excerpt = $localizedData['excerpt'] ?? [];
+        if (!\is_array($excerpt) || [] === $excerpt) {
+            return [];
+        }
+
+        $imageId = $this->extractMediaId($excerpt['images'] ?? null);
+        $iconId = $this->extractMediaId($excerpt['icon'] ?? null);
+
+        // Validate media IDs exist
+        if (null !== $imageId && !$this->entityRepository->exists('me_media', ['id' => $imageId])) {
+            $imageId = null;
+        }
+        if (null !== $iconId && !$this->entityRepository->exists('me_media', ['id' => $iconId])) {
+            $iconId = null;
+        }
+
+        $more = $excerpt['more'] ?? null;
+        // Validate excerptMore length (max 63 chars)
+        if (\is_string($more) && \strlen($more) >= 63) {
+            $more = null;
+        }
+
+        return \array_filter([
+            'title' => $excerpt['title'] ?? null,
+            'description' => $excerpt['description'] ?? null,
+            'more' => $more,
+            'image' => null !== $imageId ? ['id' => $imageId] : null,
+            'icon' => null !== $iconId ? ['id' => $iconId] : null,
+        ], static fn ($value) => null !== $value);
+    }
+
+    /**
+     * Extract media ID from various formats.
+     */
+    private function extractMediaId(mixed $value): ?int
+    {
         if (null === $value) {
-            return $data;
+            return null;
         }
 
-        if (!\is_array($value)) {
-            unset($data['excerptIconId']);
-
-            return $data;
+        if (\is_int($value)) {
+            return $value;
         }
 
-        $data['excerptIconId'] = $data['excerptIconId']['ids'][0] ?? null;
+        if (\is_array($value) && isset($value['ids'][0])) {
+            return (int) $value['ids'][0];
+        }
 
-        return $data;
+        return null;
     }
 
     /**
@@ -353,6 +371,10 @@ abstract class AbstractPersister implements PersisterInterface
                 $localizedData['availableLocales'] = $availableLocales;
             }
 
+            // Build JSON structures for seoData and excerptData (Sulu 3.0 format)
+            $localizedData['_seoData'] = $this->buildSeoData($localizedData);
+            $localizedData['_excerptData'] = $this->buildExcerptData($localizedData);
+
             $data = $this->mapDataViaMapping($localizedData, $this->getDimensionContentMapping());
             $created = $document['sulu']['created'] ?? null;
             $data['created'] = $created instanceof \DateTimeInterface ? $created->format('Y-m-d H:i:s') : null;
@@ -360,8 +382,6 @@ abstract class AbstractPersister implements PersisterInterface
             $data['changed'] = $changed instanceof \DateTimeInterface ? $changed->format('Y-m-d H:i:s') : null;
 
             $data = \array_merge($this->getDefaultData(), $data);
-            $data = $this->mapExcerptImages($data);
-            $data = $this->mapExcerptIcons($data);
             $data = $this->mapDimensionContentData($document, $locale, $data, $isLive);
 
             $data = $this->validateData($data);
@@ -433,7 +453,7 @@ abstract class AbstractPersister implements PersisterInterface
 
             $parentId = $this->getParentId($document, $locale);
             $parentRouteId = $this->getParentRouteId($parentId, $locale);
-            $site = $this->getSite($document, $locale);
+            $webspace = $this->getWebspace($document, $locale);
             $resourceId = $document['jcr']['uuid'];
             $resourceKey = $this->getEntityResourceKey();
 
@@ -448,7 +468,7 @@ abstract class AbstractPersister implements PersisterInterface
                 'resource_id' => $resourceId,
                 'locale' => $locale,
                 'slug' => $this->getSlug($document, $locale),
-                'site' => $site,
+                'webspace' => $webspace,
                 'parent_id' => $parentRouteId,
             ];
 
@@ -492,7 +512,7 @@ abstract class AbstractPersister implements PersisterInterface
                     'resource_id' => $historyResourceId,
                     'locale' => $locale,
                     'slug' => $url,
-                    'site' => $site,
+                    'webspace' => $webspace,
                     'parent_id' => null, // history urls are disconnected from the parent to prevent unexpected changes
                 ];
 
@@ -713,7 +733,7 @@ abstract class AbstractPersister implements PersisterInterface
     /**
      * @param Document $document
      */
-    protected function getSite(array $document, string $locale): ?string
+    protected function getWebspace(array $document, string $locale): ?string
     {
         return null;
     }
@@ -737,9 +757,6 @@ abstract class AbstractPersister implements PersisterInterface
     {
         $validators = [
             'author_id' => fn (mixed $value): bool => $this->entityRepository->exists('co_contacts', ['id' => $value]),
-            'excerptImageId' => fn (mixed $value): bool => $this->entityRepository->exists('me_media', ['id' => $value]),
-            'excerptIconId' => fn (mixed $value): bool => $this->entityRepository->exists('me_media', ['id' => $value]),
-            'excerptMore' => fn (mixed $value): bool => (\is_string($value) && \strlen($value) < 63) || null === $value,
         ];
 
         foreach ($validators as $key => $isValid) {

--- a/PhpcrMigration/Application/Persister/AbstractPersister.php
+++ b/PhpcrMigration/Application/Persister/AbstractPersister.php
@@ -37,6 +37,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  *         _route?: array<string, mixed>,
  *         _history_urls?: string[],
  *         _url?: ?string,
+ *         mainWebspace?: string,
+ *         additionalWebspaces?: string[],
  *     }>
  * }
  * @phpstan-type DimensionContent array{

--- a/PhpcrMigration/Application/Persister/AbstractPersister.php
+++ b/PhpcrMigration/Application/Persister/AbstractPersister.php
@@ -588,7 +588,7 @@ abstract class AbstractPersister implements PersisterInterface
      */
     protected function removeNonTemplateData(array $data): array
     {
-        unset($data['_url'], $data['_history_urls'], $data['_route'], $data['nodeType']);
+        unset($data['_url'], $data['_history_urls'], $data['_route'], $data['nodeType'], $data['_seoData'], $data['_excerptData']);
         foreach ($data as $key => $value) {
             // remove block-length property
             if (\is_array($value) && \is_int($data[$key . '-length'] ?? null)) {

--- a/PhpcrMigration/Application/Persister/ArticlePersister.php
+++ b/PhpcrMigration/Application/Persister/ArticlePersister.php
@@ -16,6 +16,10 @@ use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\RouteP
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
+/**
+ * @phpstan-import-type Document from AbstractPersister
+ * @phpstan-import-type DimensionContent from AbstractPersister
+ */
 class ArticlePersister extends AbstractPersister
 {
     public function __construct(
@@ -39,6 +43,8 @@ class ArticlePersister extends AbstractPersister
         $data['state'] = null;
         $data['availableLocales'] = null;
         $data['routePathName'] = null;
+        $data['mainWebspace'] = null;
+        $data['additionalWebspaces'] = null;
 
         return \array_filter($data, static fn ($entry) => null !== $entry);
     }
@@ -74,6 +80,9 @@ class ArticlePersister extends AbstractPersister
             $segments = $data['excerptSegment'];
             $data['excerptSegment'] = [] === $segments ? null : \reset($segments);
         }
+
+        // customizeWebspaceSettings is true if mainWebspace is set
+        $data['customizeWebspaceSettings'] = isset($document['localizations'][$locale]['mainWebspace']);
 
         return $data;
     }
@@ -137,6 +146,8 @@ class ArticlePersister extends AbstractPersister
             'excerptData' => 'json',
             'excerptSegment' => 'string',
             'templateData' => 'json',
+            'mainWebspace' => 'string',
+            'customizeWebspaceSettings' => 'boolean',
         ];
     }
 
@@ -160,6 +171,8 @@ class ArticlePersister extends AbstractPersister
             // Sulu 3.0: Excerpt data consolidated into JSON column
             '[excerptData]' => '[_excerptData]',
             '[excerptSegment]' => '[excerpt][segments]',
+            // Sulu 3.0: Webspace settings
+            '[mainWebspace]' => '[mainWebspace]',
         ];
     }
 
@@ -246,7 +259,55 @@ class ArticlePersister extends AbstractPersister
             'seoNoIndex' => false,
             'seoNoFollow' => false,
             'seoHideInSitemap' => false,
+            'customizeWebspaceSettings' => false,
         ];
+    }
+
+    protected function insertDataRelationsToDimensionContent(array $document, ?string $locale, array $dimensionContent): void
+    {
+        parent::insertDataRelationsToDimensionContent($document, $locale, $dimensionContent);
+        $this->insertOrUpdateAdditionalWebspaces($document, $locale, $dimensionContent);
+    }
+
+    /**
+     * @param Document $document
+     * @param DimensionContent $dimensionContent
+     */
+    private function insertOrUpdateAdditionalWebspaces(array $document, ?string $locale, array $dimensionContent): void
+    {
+        if (null === $locale) {
+            return;
+        }
+
+        if (!isset($document['localizations'][$locale])) {
+            return;
+        }
+
+        $additionalWebspaces = $document['localizations'][$locale]['additionalWebspaces'] ?? null;
+
+        if (null === $additionalWebspaces) {
+            return;
+        }
+
+        $tableName = 'ar_article_dimension_content_additional_webspaces';
+
+        $this->entityRepository->removeBy($tableName, [
+            'article_dimension_content_id' => $dimensionContent['id'],
+        ]);
+
+        foreach ($additionalWebspaces as $webspace) {
+            $this->entityRepository->insertOrUpdate(
+                [
+                    'article_dimension_content_id' => $dimensionContent['id'],
+                    'name' => $webspace,
+                ],
+                $tableName,
+                [
+                    'article_dimension_content_id' => 'integer',
+                    'name' => 'string',
+                ],
+            );
+        }
     }
 
     protected function isRoutable(): bool

--- a/PhpcrMigration/Application/Persister/ArticlePersister.php
+++ b/PhpcrMigration/Application/Persister/ArticlePersister.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
 
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\InvalidPathException;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\RoutePathNameNotFoundException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -129,19 +130,12 @@ class ArticlePersister extends AbstractPersister
             'stage' => 'string',
             'workflowPlace' => 'string',
             'workflowPublished' => 'datetime',
-            'seoTitle' => 'string',
-            'seoDescription' => 'string',
-            'seoKeywords' => 'string',
-            'seoCanonicalUrl' => 'string',
+            'seoData' => 'json',
             'seoNoIndex' => 'boolean',
             'seoNoFollow' => 'boolean',
             'seoHideInSitemap' => 'boolean',
-            'excerptTitle' => 'string',
-            'excerptMore' => 'string',
-            'excerptDescription' => 'string',
+            'excerptData' => 'json',
             'excerptSegment' => 'string',
-            'excerptImageId' => 'integer',
-            'excerptIconId' => 'integer',
             'templateData' => 'json',
         ];
     }
@@ -158,19 +152,14 @@ class ArticlePersister extends AbstractPersister
             '[templateKey]' => '[template]',
             '[workflowPlace]' => '[state]',
             '[workflowPublished]' => '[published]',
-            '[seoTitle]' => '[seo][title]',
-            '[seoDescription]' => '[seo][description]',
-            '[seoKeywords]' => '[seo][keywords]',
-            '[seoCanonicalUrl]' => '[seo][canonicalUrl]',
+            // Sulu 3.0: SEO data consolidated into JSON column
+            '[seoData]' => '[_seoData]',
             '[seoNoIndex]' => '[seo][noIndex]',
             '[seoNoFollow]' => '[seo][noFollow]',
             '[seoHideInSitemap]' => '[seo][hideInSitemap]',
-            '[excerptTitle]' => '[excerpt][title]',
-            '[excerptMore]' => '[excerpt][more]',
-            '[excerptDescription]' => '[excerpt][description]',
+            // Sulu 3.0: Excerpt data consolidated into JSON column
+            '[excerptData]' => '[_excerptData]',
             '[excerptSegment]' => '[excerpt][segments]',
-            '[excerptImageId]' => '[excerpt][images]',
-            '[excerptIconId]' => '[excerpt][icon]',
         ];
     }
 
@@ -218,9 +207,29 @@ class ArticlePersister extends AbstractPersister
     {
         $localizedData = $document['localizations'][$locale];
 
-        if (!isset($localizedData['routePath'])) {
-            throw new InvalidPathException('routePath');
+        // Check if both routePath and routePathName are missing
+        if (!isset($localizedData['routePath']) && !isset($localizedData['routePathName'])) {
+            throw new RoutePathNameNotFoundException($document['jcr']['uuid'], $locale);
         }
+
+        // If routePathName is set, use it to find the route property
+        if (isset($localizedData['routePathName'])) {
+            $routePathName = $localizedData['routePathName'];
+            // Handle i18n prefix (e.g., 'i18n:en-routePath' -> 'routePath')
+            $routePathName = \str_starts_with($routePathName, 'i18n:')
+                ? \explode('-', $routePathName, 2)[1]
+                : $routePathName;
+
+            $routePath = $localizedData[$routePathName] ?? null;
+            if (!\is_string($routePath)) {
+                throw new InvalidPathException($routePathName);
+            }
+
+            return $routePath;
+        }
+
+        // At this point routePath must exist (we checked above)
+        \assert(isset($localizedData['routePath']));
 
         return $localizedData['routePath'];
     }

--- a/PhpcrMigration/Application/Persister/PagePersister.php
+++ b/PhpcrMigration/Application/Persister/PagePersister.php
@@ -192,19 +192,12 @@ class PagePersister extends AbstractPersister
             'availableLocales' => 'json',
             'templateKey' => 'string',
             'templateData' => 'json',
-            'seoTitle' => 'string',
-            'seoDescription' => 'string',
-            'seoKeywords' => 'string',
-            'seoCanonicalUrl' => 'string',
+            'seoData' => 'json',
             'seoNoIndex' => 'boolean',
             'seoNoFollow' => 'boolean',
             'seoHideInSitemap' => 'boolean',
-            'excerptTitle' => 'string',
-            'excerptMore' => 'string',
-            'excerptDescription' => 'string',
+            'excerptData' => 'json',
             'excerptSegment' => 'string',
-            'excerptImageId' => 'integer',
-            'excerptIconId' => 'integer',
             'authored' => 'datetime',
             'lastModified' => 'datetime',
             'workflowPlace' => 'string',
@@ -225,19 +218,14 @@ class PagePersister extends AbstractPersister
             '[templateKey]' => '[template]',
             '[workflowPlace]' => '[state]',
             '[workflowPublished]' => '[published]',
-            '[seoTitle]' => '[seo][title]',
-            '[seoDescription]' => '[seo][description]',
-            '[seoKeywords]' => '[seo][keywords]',
-            '[seoCanonicalUrl]' => '[seo][canonicalUrl]',
+            // Sulu 3.0: SEO data consolidated into JSON column
+            '[seoData]' => '[_seoData]',
             '[seoNoIndex]' => '[seo][noIndex]',
             '[seoNoFollow]' => '[seo][noFollow]',
             '[seoHideInSitemap]' => '[seo][hideInSitemap]',
-            '[excerptTitle]' => '[excerpt][title]',
-            '[excerptMore]' => '[excerpt][more]',
-            '[excerptDescription]' => '[excerpt][description]',
+            // Sulu 3.0: Excerpt data consolidated into JSON column
+            '[excerptData]' => '[_excerptData]',
             '[excerptSegment]' => '[excerpt][segments]',
-            '[excerptImageId]' => '[excerpt][images]',
-            '[excerptIconId]' => '[excerpt][icon]',
         ];
     }
 
@@ -295,7 +283,7 @@ class PagePersister extends AbstractPersister
         return $localizedData[AbstractPersister::URL];
     }
 
-    protected function getSite(array $document, string $locale): ?string
+    protected function getWebspace(array $document, string $locale): ?string
     {
         /** @var array{webspaceKey?: string} $data */
         $data = $document['sulu'];

--- a/PhpcrMigration/Application/Persister/SnippetPersister.php
+++ b/PhpcrMigration/Application/Persister/SnippetPersister.php
@@ -117,12 +117,8 @@ class SnippetPersister extends AbstractPersister
             'availableLocales' => 'json',
             'templateKey' => 'string',
             'templateData' => 'json',
-            'excerptTitle' => 'string',
-            'excerptMore' => 'string',
-            'excerptDescription' => 'string',
+            'excerptData' => 'json',
             'excerptSegment' => 'string',
-            'excerptImageId' => 'integer',
-            'excerptIconId' => 'integer',
             'authored' => 'datetime',
             'workflowPlace' => 'string',
             'workflowPublished' => 'datetime',
@@ -131,7 +127,6 @@ class SnippetPersister extends AbstractPersister
 
     protected function getDimensionContentMapping(): array
     {
-        //TODO
         return [
             '[author_id]' => '[author]',
             '[authored]' => '[authored]',
@@ -141,12 +136,9 @@ class SnippetPersister extends AbstractPersister
             '[templateKey]' => '[template]',
             '[workflowPlace]' => '[state]',
             '[workflowPublished]' => '[published]',
-            '[excerptTitle]' => '[excerpt][title]',
-            '[excerptMore]' => '[excerpt][more]',
-            '[excerptDescription]' => '[excerpt][description]',
+            // Sulu 3.0: Excerpt data consolidated into JSON column
+            '[excerptData]' => '[_excerptData]',
             '[excerptSegment]' => '[excerpt][segments]',
-            '[excerptImageId]' => '[excerpt][images]',
-            '[excerptIconId]' => '[excerpt][icon]',
         ];
     }
 

--- a/PhpcrMigration/Application/Persister/SnippetPersister.php
+++ b/PhpcrMigration/Application/Persister/SnippetPersister.php
@@ -55,13 +55,6 @@ class SnippetPersister extends AbstractPersister
             $data['templateData']['title'] = $data['title'];
         }
 
-        // Transform segments map to single segment value
-        // For snippets, take the first segment value from the map
-        if (isset($data['excerptSegment']) && \is_array($data['excerptSegment'])) {
-            $segments = $data['excerptSegment'];
-            $data['excerptSegment'] = [] === $segments ? null : \reset($segments);
-        }
-
         return $data;
     }
 
@@ -117,8 +110,6 @@ class SnippetPersister extends AbstractPersister
             'availableLocales' => 'json',
             'templateKey' => 'string',
             'templateData' => 'json',
-            'excerptData' => 'json',
-            'excerptSegment' => 'string',
             'authored' => 'datetime',
             'workflowPlace' => 'string',
             'workflowPublished' => 'datetime',
@@ -136,9 +127,6 @@ class SnippetPersister extends AbstractPersister
             '[templateKey]' => '[template]',
             '[workflowPlace]' => '[state]',
             '[workflowPublished]' => '[published]',
-            // Sulu 3.0: Excerpt data consolidated into JSON column
-            '[excerptData]' => '[_excerptData]',
-            '[excerptSegment]' => '[excerpt][segments]',
         ];
     }
 

--- a/PhpcrMigration/Application/Persister/SnippetPersister.php
+++ b/PhpcrMigration/Application/Persister/SnippetPersister.php
@@ -55,6 +55,13 @@ class SnippetPersister extends AbstractPersister
             $data['templateData']['title'] = $data['title'];
         }
 
+        // Snippets store template as unlocalized property (same template for all locales)
+        if (null === $locale) {
+            $data['templateKey'] = null;
+        } elseif (!isset($data['templateKey']) && isset($document['localizations']['null']['template'])) {
+            $data['templateKey'] = $document['localizations']['null']['template'];
+        }
+
         return $data;
     }
 

--- a/PhpcrMigration/Infrastructure/Repository/EntityRepository.php
+++ b/PhpcrMigration/Infrastructure/Repository/EntityRepository.php
@@ -108,7 +108,11 @@ class EntityRepository implements EntityRepositoryInterface, ResetInterface
 
     public function tableExists(string $tableName): bool
     {
-        return $this->connection->createSchemaManager()->tablesExist([$tableName]);
+        // Bypass Doctrine's schema_filter which excludes ro_routes_old
+        $databaseName = $this->connection->getDatabase();
+        $sql = 'SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?';
+
+        return false !== $this->connection->fetchOne($sql, [$databaseName, $tableName]);
     }
 
     /**


### PR DESCRIPTION
- Add support for additional webspaces in the migration process
- Remove excerpt handling from snippets (not applicable in Sulu 3.0)
- Fix column mapping issues in persisters
- Various bug fixes in the persister layer

Changes

- AbstractPersister: Refactored excerpt and webspace handling logic
- ArticlePersister: Extended to support multi-webspace scenarios
- PagePersister: Fixed column mappings
- SnippetPersister: Simplified by removing excerpt logic
- EntityRepository: Minor fixes