### PR TITLE
Fix migration crash for unpublished articles without routes

### DIFF
--- a/PhpcrMigration/Application/Persister/ArticlePersister.php
+++ b/PhpcrMigration/Application/Persister/ArticlePersister.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
 
-use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\InvalidPathException;
-use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\RoutePathNameNotFoundException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -63,14 +61,13 @@ class ArticlePersister extends AbstractPersister
             $data['templateData']['title'] = $data['title'];
         }
 
-        if (isset($document['localizations'][$locale]['routePathName']) && isset($document['localizations'][$locale]['routePath'])) {
-            $routePathName = $document['localizations'][$locale]['routePathName'];
-            $routePathName = \str_starts_with($routePathName, 'i18n:') ? \explode('-', $routePathName, 2)[1] : $routePathName;
-            // check routePathName property and fallback to routePath
-            $routePath = $document['localizations'][$locale][$routePathName] ?? $document['localizations'][$locale]['routePath'];
+        if (null !== $locale && isset($document['localizations'][$locale])) {
+            $url = $this->resolveRoutePath($document['localizations'][$locale]);
 
-            // content bundle is only compatible with "url"
-            $data['templateData']['url'] = $routePath; // is used in the content bundle
+            if (null !== $url) {
+                // content bundle is only compatible with "url"
+                $data['templateData']['url'] = $url;
+            }
         }
 
         // Transform segments map to single segment value
@@ -215,35 +212,42 @@ class ArticlePersister extends AbstractPersister
         return 'article_dimension_content_id';
     }
 
-    protected function getSlug(array $document, string $locale): string
+    /**
+     * Resolves the route path from localized PHPCR data.
+     * Uses routePathName to find the actual property, falls back to routePath.
+     *
+     * @param array<string, mixed> $localeData
+     */
+    private function resolveRoutePath(array $localeData): ?string
     {
-        $localizedData = $document['localizations'][$locale];
-
-        // Check if both routePath and routePathName are missing
-        if (!isset($localizedData['routePath']) && !isset($localizedData['routePathName'])) {
-            throw new RoutePathNameNotFoundException($document['jcr']['uuid'], $locale);
-        }
-
-        // If routePathName is set, use it to find the route property
-        if (isset($localizedData['routePathName'])) {
-            $routePathName = $localizedData['routePathName'];
+        if (isset($localeData['routePathName']) && \is_string($localeData['routePathName'])) {
+            $routePathName = $localeData['routePathName'];
             // Handle i18n prefix (e.g., 'i18n:en-routePath' -> 'routePath')
             $routePathName = \str_starts_with($routePathName, 'i18n:')
                 ? \explode('-', $routePathName, 2)[1]
                 : $routePathName;
 
-            $routePath = $localizedData[$routePathName] ?? null;
-            if (!\is_string($routePath)) {
-                throw new InvalidPathException($routePathName);
+            $resolved = $localeData[$routePathName] ?? null;
+
+            if (\is_string($resolved)) {
+                return $resolved;
             }
 
-            return $routePath;
+            // Fall through to routePath if routePathName didn't resolve
         }
 
-        // At this point routePath must exist (we checked above)
-        \assert(isset($localizedData['routePath']));
+        $routePath = $localeData['routePath'] ?? null;
 
-        return $localizedData['routePath'];
+        return \is_string($routePath) ? $routePath : null;
+    }
+
+    protected function getSlug(array $document, string $locale): ?string
+    {
+        if (!isset($document['localizations'][$locale])) {
+            return null;
+        }
+
+        return $this->resolveRoutePath($document['localizations'][$locale]);
     }
 
     protected function getParentId(array $document, string $locale): ?string

--- a/Tests/Resources/baselines/ar_article_dimension_contents.json
+++ b/Tests/Resources/baselines/ar_article_dimension_contents.json
@@ -91,7 +91,8 @@
                 "timezone": "+00:00",
                 "timezone_type": 1
             },
-            "title": "Example article"
+            "title": "Example article",
+            "url": "/blog/example-article"
         },
         "templateKey": "default",
         "title": "Example article",
@@ -182,7 +183,8 @@
         "stage": "draft",
         "templateData": {
             "blocks": [],
-            "title": "Timestamp Fallback Article"
+            "title": "Timestamp Fallback Article",
+            "url": "/blog/timestamp-fallback-article"
         },
         "templateKey": "blog",
         "title": "Timestamp Fallback Article",
@@ -282,7 +284,8 @@
                 "timezone": "+00:00",
                 "timezone_type": 1
             },
-            "title": "Example article"
+            "title": "Example article",
+            "url": "/blog/example-article"
         },
         "templateKey": "default",
         "title": "Example article",
@@ -373,7 +376,8 @@
         "stage": "live",
         "templateData": {
             "blocks": [],
-            "title": "Timestamp Fallback Article"
+            "title": "Timestamp Fallback Article",
+            "url": "/blog/timestamp-fallback-article"
         },
         "templateKey": "blog",
         "title": "Timestamp Fallback Article",


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #36
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Handle missing route properties gracefully in `ArticlePersister::mapDimensionContentData()` — no longer requires both `routePathName` AND `routePath` to be set
  - Change `getSlug()` return type to `?string` to match the parent contract, allowing the route creation to skip locales without routes
  - Keep exceptions for published articles missing route properties, as this indicates PHPCR migrations were not run before updating

  > **Note:** This PR builds upon #36 and should be merged after it.

  #### Why?

  Articles that were never published do not have route properties (`routePath`, `routePathName`) in PHPCR. The migration crashed when processing these articles because `mapDimensionContentData` required both
  properties to be set simultaneously.