### PR TITLE
Fix title trim to 191 and add exception for to long slug

### DIFF
--- a/PhpcrMigration/Application/Exception/SlugTooLongException.php
+++ b/PhpcrMigration/Application/Exception/SlugTooLongException.php
@@ -15,13 +15,16 @@ namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception;
 
 class SlugTooLongException extends \RuntimeException
 {
+    public const MAX_LENGTH = 144;
+
     public function __construct(string $slug, string $uuid, string $locale)
     {
         parent::__construct(\sprintf(
-            'Slug "%s" for document "%s" (locale: %s) exceeds the maximum length of 144 characters.',
+            'Slug "%s" for document "%s" (locale: %s) exceeds the maximum length of %d characters.',
             $slug,
             $uuid,
             $locale,
+            self::MAX_LENGTH,
         ));
     }
 }

--- a/PhpcrMigration/Application/Exception/SlugTooLongException.php
+++ b/PhpcrMigration/Application/Exception/SlugTooLongException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception;
+
+class SlugTooLongException extends \RuntimeException
+{
+    public function __construct(string $slug, string $uuid, string $locale)
+    {
+        parent::__construct(\sprintf(
+            'Slug "%s" for document "%s" (locale: %s) exceeds the maximum length of 144 characters.',
+            $slug,
+            $uuid,
+            $locale,
+        ));
+    }
+}

--- a/PhpcrMigration/Application/Exception/TitleTooLongException.php
+++ b/PhpcrMigration/Application/Exception/TitleTooLongException.php
@@ -15,13 +15,16 @@ namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception;
 
 class TitleTooLongException extends \RuntimeException
 {
+    public const MAX_LENGTH = 191;
+
     public function __construct(string $title, string $uuid, ?string $locale)
     {
         parent::__construct(\sprintf(
-            'Title "%s" for document "%s" (locale: %s) exceeds the maximum length of 191 characters.',
+            'Title "%s" for document "%s" (locale: %s) exceeds the maximum length of %d characters.',
             $title,
             $uuid,
             $locale ?? 'null',
+            self::MAX_LENGTH,
         ));
     }
 }

--- a/PhpcrMigration/Application/Exception/TitleTooLongException.php
+++ b/PhpcrMigration/Application/Exception/TitleTooLongException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception;
+
+class TitleTooLongException extends \RuntimeException
+{
+    public function __construct(string $title, string $uuid, ?string $locale)
+    {
+        parent::__construct(\sprintf(
+            'Title "%s" for document "%s" (locale: %s) exceeds the maximum length of 191 characters.',
+            $title,
+            $uuid,
+            $locale ?? 'null',
+        ));
+    }
+}

--- a/PhpcrMigration/Application/Persister/AbstractPersister.php
+++ b/PhpcrMigration/Application/Persister/AbstractPersister.php
@@ -540,7 +540,7 @@ abstract class AbstractPersister implements PersisterInterface
                 continue;
             }
 
-            if (\strlen($slug) > 144) {
+            if (\strlen($slug) > SlugTooLongException::MAX_LENGTH) {
                 throw new SlugTooLongException($slug, $document['jcr']['uuid'], $locale);
             }
 

--- a/PhpcrMigration/Application/Persister/AbstractPersister.php
+++ b/PhpcrMigration/Application/Persister/AbstractPersister.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
 
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\InvalidDocumentException;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\SlugTooLongException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\UnsupportedDocumentTypeException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -539,6 +540,10 @@ abstract class AbstractPersister implements PersisterInterface
                 continue;
             }
 
+            if (\strlen($slug) > 144) {
+                throw new SlugTooLongException($slug, $document['jcr']['uuid'], $locale);
+            }
+
             // main route
             $data = [
                 'resource_key' => $resourceKey,
@@ -589,6 +594,10 @@ abstract class AbstractPersister implements PersisterInterface
 
             $historyResourceId = $resourceKey . '::' . $resourceId;
             foreach ($historyUrls as $url) {
+                if (\strlen($url) > 144) {
+                    throw new SlugTooLongException($url, $document['jcr']['uuid'], $locale);
+                }
+
                 $data = [
                     'resource_key' => AbstractPersister::ROUTE_RESOURCE_KEY,
                     'resource_id' => $historyResourceId,

--- a/PhpcrMigration/Application/Persister/ArticlePersister.php
+++ b/PhpcrMigration/Application/Persister/ArticlePersister.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
 
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\TitleTooLongException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -57,8 +58,14 @@ class ArticlePersister extends AbstractPersister
         $data['workflowPlace'] = 2 === ($data['workflowPlace'] ?? null) ? 'published' : 'draft';
 
         if (isset($data['title'])) {
-            $data['title'] = \str_split((string) $data['title'], 191)[0];
-            $data['templateData']['title'] = $data['title'];
+            $title = (string) $data['title'];
+
+            if (\strlen($title) > 191) {
+                throw new TitleTooLongException($title, $document['jcr']['uuid'], $locale);
+            }
+
+            $data['title'] = $title;
+            $data['templateData']['title'] = $title;
         }
 
         if (null !== $locale && isset($document['localizations'][$locale])) {

--- a/PhpcrMigration/Application/Persister/ArticlePersister.php
+++ b/PhpcrMigration/Application/Persister/ArticlePersister.php
@@ -57,7 +57,7 @@ class ArticlePersister extends AbstractPersister
         $data['workflowPlace'] = 2 === ($data['workflowPlace'] ?? null) ? 'published' : 'draft';
 
         if (isset($data['title'])) {
-            $data['title'] = \str_split((string) $data['title'], 64)[0];
+            $data['title'] = \str_split((string) $data['title'], 191)[0];
             $data['templateData']['title'] = $data['title'];
         }
 

--- a/PhpcrMigration/Application/Persister/ArticlePersister.php
+++ b/PhpcrMigration/Application/Persister/ArticlePersister.php
@@ -60,7 +60,7 @@ class ArticlePersister extends AbstractPersister
         if (isset($data['title'])) {
             $title = (string) $data['title'];
 
-            if (\strlen($title) > 191) {
+            if (\strlen($title) > TitleTooLongException::MAX_LENGTH) {
                 throw new TitleTooLongException($title, $document['jcr']['uuid'], $locale);
             }
 

--- a/PhpcrMigration/Application/Persister/PagePersister.php
+++ b/PhpcrMigration/Application/Persister/PagePersister.php
@@ -67,7 +67,7 @@ class PagePersister extends AbstractPersister
         if (isset($data['title'])) {
             $title = (string) $data['title'];
 
-            if (\strlen($title) > 191) {
+            if (\strlen($title) > TitleTooLongException::MAX_LENGTH) {
                 throw new TitleTooLongException($title, $document['jcr']['uuid'], $locale);
             }
 

--- a/PhpcrMigration/Application/Persister/PagePersister.php
+++ b/PhpcrMigration/Application/Persister/PagePersister.php
@@ -64,8 +64,7 @@ class PagePersister extends AbstractPersister
         $data['workflowPlace'] = null === $locale ? null : (2 === ($data['workflowPlace'] ?? null) ? 'published' : 'draft');
 
         if (isset($data['title'])) {
-            // TODO error collector with titles that were too long
-            $data['title'] = \str_split((string) $data['title'], 63)[0] ?? '';
+            $data['title'] = \str_split((string) $data['title'], 191)[0] ?? '';
             $data['templateData']['title'] = $data['title'];
         }
 

--- a/PhpcrMigration/Application/Persister/PagePersister.php
+++ b/PhpcrMigration/Application/Persister/PagePersister.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
 
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\InvalidDocumentException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\InvalidPathException;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\TitleTooLongException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -64,8 +65,14 @@ class PagePersister extends AbstractPersister
         $data['workflowPlace'] = null === $locale ? null : (2 === ($data['workflowPlace'] ?? null) ? 'published' : 'draft');
 
         if (isset($data['title'])) {
-            $data['title'] = \str_split((string) $data['title'], 191)[0] ?? '';
-            $data['templateData']['title'] = $data['title'];
+            $title = (string) $data['title'];
+
+            if (\strlen($title) > 191) {
+                throw new TitleTooLongException($title, $document['jcr']['uuid'], $locale);
+            }
+
+            $data['title'] = $title;
+            $data['templateData']['title'] = $title;
         }
 
         if (isset($document['localizations'][$locale]['routePathName']) && isset($document['localizations'][$locale]['routePath'])) {

--- a/PhpcrMigration/Application/Persister/SnippetPersister.php
+++ b/PhpcrMigration/Application/Persister/SnippetPersister.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister;
 
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Exception\TitleTooLongException;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -50,8 +51,14 @@ class SnippetPersister extends AbstractPersister
         $data['workflowPlace'] = 'published';
 
         if (isset($data['title'])) {
-            $data['title'] = \str_split((string) $data['title'], 191)[0];
-            $data['templateData']['title'] = $data['title'];
+            $title = (string) $data['title'];
+
+            if (\strlen($title) > 191) {
+                throw new TitleTooLongException($title, $document['jcr']['uuid'], $locale);
+            }
+
+            $data['title'] = $title;
+            $data['templateData']['title'] = $title;
         }
 
         // Snippets store template as unlocalized property (same template for all locales)

--- a/PhpcrMigration/Application/Persister/SnippetPersister.php
+++ b/PhpcrMigration/Application/Persister/SnippetPersister.php
@@ -50,8 +50,7 @@ class SnippetPersister extends AbstractPersister
         $data['workflowPlace'] = 'published';
 
         if (isset($data['title'])) {
-            // TODO error collector with titles that were too long
-            $data['title'] = \str_split((string) $data['title'], 64)[0];
+            $data['title'] = \str_split((string) $data['title'], 191)[0];
             $data['templateData']['title'] = $data['title'];
         }
 

--- a/PhpcrMigration/Application/Persister/SnippetPersister.php
+++ b/PhpcrMigration/Application/Persister/SnippetPersister.php
@@ -53,7 +53,7 @@ class SnippetPersister extends AbstractPersister
         if (isset($data['title'])) {
             $title = (string) $data['title'];
 
-            if (\strlen($title) > 191) {
+            if (\strlen($title) > TitleTooLongException::MAX_LENGTH) {
                 throw new TitleTooLongException($title, $document['jcr']['uuid'], $locale);
             }
 


### PR DESCRIPTION
Update title trim to 191 and add exception for to long slug.
No error collector because in Sulu 2.6 title also had a maximum length.

Fixes https://github.com/sulu/SuluPHPCRMigrationBundle/issues/39
