### PR TITLE
Fix missing provider key in linkData migration

### DIFF
--- a/PhpcrMigration/Application/Persister/PagePersister.php
+++ b/PhpcrMigration/Application/Persister/PagePersister.php
@@ -171,6 +171,7 @@ class PagePersister extends AbstractPersister
             $targetUuid = $localization['internal_link'] ?? null;
             $data['linkProvider'] = 'page'; // Sulu 2.6 did only support 'page' as internal link provider
             $data['linkData'] = null !== $targetUuid ? [
+                'provider' => 'page',
                 'href' => $targetUuid,
                 'locale' => $locale,
             ] : null;
@@ -179,6 +180,7 @@ class PagePersister extends AbstractPersister
             $externalUrl = $localization['external'] ?? null;
             $data['linkProvider'] = 'external';
             $data['linkData'] = null !== $externalUrl ? [
+                'provider' => 'external',
                 'href' => $externalUrl,
                 'locale' => $locale,
             ] : null;

--- a/Tests/Resources/baselines/pa_page_dimension_contents.json
+++ b/Tests/Resources/baselines/pa_page_dimension_contents.json
@@ -1252,7 +1252,7 @@
         "availableLocales": [
             "de"
         ],
-        "changed": "2026-03-31 11:45:41",
+        "changed": "2026-04-12 22:58:59",
         "created": "2025-12-11 22:03:04",
         "excerptData": {
             "description": null,
@@ -1295,7 +1295,7 @@
         "author_id": 1,
         "authored": "2025-12-11 22:03:04",
         "availableLocales": "",
-        "changed": "2026-03-31 11:45:41",
+        "changed": "2026-04-12 22:58:59",
         "created": "2025-12-11 22:03:04",
         "excerptData": {
             "description": "",
@@ -1551,7 +1551,8 @@
         "lastModified": "2025-12-09 10:53:04",
         "linkData": {
             "href": "http://sulu.io",
-            "locale": "de"
+            "locale": "de",
+            "provider": "external"
         },
         "linkProvider": "external",
         "locale": "de",
@@ -1862,7 +1863,8 @@
         "lastModified": "2025-12-09 10:53:25",
         "linkData": {
             "href": "16060395-4bbf-4e1d-9c8e-fe5265890c99",
-            "locale": "de"
+            "locale": "de",
+            "provider": "page"
         },
         "linkProvider": "page",
         "locale": "de",
@@ -3258,7 +3260,7 @@
         "availableLocales": [
             "de"
         ],
-        "changed": "2026-03-31 11:45:41",
+        "changed": "2026-04-12 22:58:59",
         "created": "2025-12-11 22:03:04",
         "excerptData": {
             "description": null,
@@ -3301,7 +3303,7 @@
         "author_id": 1,
         "authored": "2025-12-11 22:03:04",
         "availableLocales": "",
-        "changed": "2026-03-31 11:45:41",
+        "changed": "2026-04-12 22:58:59",
         "created": "2025-12-11 22:03:04",
         "excerptData": {
             "description": "",
@@ -3451,7 +3453,8 @@
         "lastModified": "2025-12-09 10:53:04",
         "linkData": {
             "href": "http://sulu.io",
-            "locale": "de"
+            "locale": "de",
+            "provider": "external"
         },
         "linkProvider": "external",
         "locale": "de",
@@ -3662,7 +3665,8 @@
         "lastModified": "2025-12-09 10:53:25",
         "linkData": {
             "href": "16060395-4bbf-4e1d-9c8e-fe5265890c99",
-            "locale": "de"
+            "locale": "de",
+            "provider": "page"
         },
         "linkProvider": "page",
         "locale": "de",

--- a/Tests/Resources/baselines/pa_pages.json
+++ b/Tests/Resources/baselines/pa_pages.json
@@ -96,7 +96,7 @@
         "webspaceKey": "website"
     },
     {
-        "changed": "2026-03-31 11:45:41",
+        "changed": "2026-04-12 22:58:59",
         "created": "2025-12-11 22:03:04",
         "depth": 1,
         "idUsersChanger": "",


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Fixed missing `provider` key in `linkData` for pages with internal and external links

  #### Why?

  The `linkData` array was missing the `provider` field after migration, causing internal/external link references to be incomplete in Sulu 3.0.
