### PR TITLE
Add dry run mode

### DIFF
--- a/PhpcrMigration/Application/Repository/EntityRepositoryInterface.php
+++ b/PhpcrMigration/Application/Repository/EntityRepositoryInterface.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository
 
 interface EntityRepositoryInterface
 {
+    public function setDryRun(bool $dryRun): void;
+
     public function beginTransaction(): void;
 
     public function commit(): void;

--- a/PhpcrMigration/Application/Service/DryRunCollector.php
+++ b/PhpcrMigration/Application/Service/DryRunCollector.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Service;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DryRunCollector
+{
+    /**
+     * @var list<array{
+     *     documentType: string,
+     *     workspace: string,
+     *     uuid: string,
+     *     path: string,
+     *     exceptionClass: string,
+     *     message: string,
+     *     timestamp: string,
+     * }>
+     */
+    private array $errors = [];
+
+    /**
+     * @var array<string, int> keyed by "$documentType|$workspace"
+     */
+    private array $processedNodes = [];
+
+    public function recordProcessed(string $documentType, string $workspace): void
+    {
+        $key = $this->buildKey($documentType, $workspace);
+        $this->processedNodes[$key] = ($this->processedNodes[$key] ?? 0) + 1;
+    }
+
+    /**
+     * @param array{documentType: string, workspace: string, uuid: string, path: string} $context
+     */
+    public function record(\Throwable $e, array $context): void
+    {
+        $fqcn = $e::class;
+        $lastSeparator = \strrpos($fqcn, '\\');
+
+        $this->errors[] = [
+            'documentType' => $context['documentType'],
+            'workspace' => $context['workspace'],
+            'uuid' => $context['uuid'],
+            'path' => $context['path'],
+            'exceptionClass' => false === $lastSeparator ? $fqcn : \substr($fqcn, $lastSeparator + 1),
+            'message' => $e->getMessage(),
+            'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    private function buildKey(string $documentType, string $workspace): string
+    {
+        return $documentType . '|' . $workspace;
+    }
+
+    /**
+     * @return array{
+     *     dryRunAt: string,
+     *     totalNodes: int,
+     *     totalErrors: int,
+     *     errors: list<array<string, mixed>>,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'dryRunAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'totalNodes' => (int) \array_sum($this->processedNodes),
+            'totalErrors' => \count($this->errors),
+            'errors' => $this->errors,
+        ];
+    }
+
+    public function printSummary(SymfonyStyle $io): void
+    {
+        $io->writeln('');
+        $io->writeln('Dry run complete — NO data was written to the database.');
+        $io->writeln('=======================================================');
+
+        $grouped = [];
+        foreach ($this->errors as $error) {
+            $key = $this->buildKey($error['documentType'], $error['workspace']);
+            $grouped[$key] ??= [];
+            $grouped[$key][$error['exceptionClass']] = ($grouped[$key][$error['exceptionClass']] ?? 0) + 1;
+        }
+
+        $allKeys = \array_unique(\array_merge(\array_keys($this->processedNodes), \array_keys($grouped)));
+        \sort($allKeys);
+
+        foreach ($allKeys as $key) {
+            [$documentType, $workspace] = \explode('|', $key, 2);
+            $nodeCount = $this->processedNodes[$key] ?? 0;
+            $errorTypes = $grouped[$key] ?? [];
+            $errorTotal = (int) \array_sum($errorTypes);
+
+            $io->writeln(\sprintf('%s (%s): %d nodes processed, %d errors', $documentType, $workspace, $nodeCount, $errorTotal));
+
+            foreach ($errorTypes as $exceptionClass => $count) {
+                $io->writeln(\sprintf('  %s x%d', $exceptionClass, $count));
+            }
+            $io->writeln('');
+        }
+
+        $io->writeln(\sprintf('Total errors: %d', \count($this->errors)));
+    }
+}

--- a/PhpcrMigration/Infrastructure/Repository/EntityRepository.php
+++ b/PhpcrMigration/Infrastructure/Repository/EntityRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -40,23 +42,44 @@ class EntityRepository implements EntityRepositoryInterface, ResetInterface
      */
     private array $existsCache = [];
 
+    private const DRY_RUN_STUB_ROW = ['id' => 0, 'depth' => 0];
+
+    private bool $dryRun = false;
+
     public function __construct(
         protected Connection $connection,
     ) {
     }
 
+    public function setDryRun(bool $dryRun): void
+    {
+        $this->dryRun = $dryRun;
+    }
+
     public function beginTransaction(): void
     {
+        if ($this->dryRun) {
+            return;
+        }
+
         $this->connection->beginTransaction();
     }
 
     public function commit(): void
     {
+        if ($this->dryRun) {
+            return;
+        }
+
         $this->connection->commit();
     }
 
     public function insertOrUpdate(array $data, string $tableName, array $types, array $where = []): void
     {
+        if ($this->dryRun) {
+            return;
+        }
+
         $exists = [] !== $where && $this->exists($tableName, $where);
 
         if ($exists) {
@@ -91,6 +114,12 @@ class EntityRepository implements EntityRepositoryInterface, ResetInterface
 
     public function findOneBy(string $tableName, array $where): ?array
     {
+        if ($this->dryRun) {
+            // Stubbed row so downstream persister logic (excerpt relations, nested-set
+            // depth lookups, parent-route resolution) has something to work with.
+            return self::DRY_RUN_STUB_ROW;
+        }
+
         [$conditions, $params] = $this->parseWhereParts($where);
 
         $query = 'SELECT * FROM ' . $tableName . ' WHERE ' . \implode(' AND ', $conditions);
@@ -134,6 +163,10 @@ class EntityRepository implements EntityRepositoryInterface, ResetInterface
 
     public function removeBy(string $tableName, array $where): int|string
     {
+        if ($this->dryRun) {
+            return 0;
+        }
+
         [$conditions, $params] = $this->parseWhereParts($where);
 
         $query = 'DELETE FROM ' . $tableName . ' WHERE ' . \implode(' AND ', $conditions);
@@ -185,6 +218,10 @@ class EntityRepository implements EntityRepositoryInterface, ResetInterface
      */
     public function createOrUpdateRootNode(array $data, string $tableName, array $types, array $where = []): void
     {
+        if ($this->dryRun) {
+            return;
+        }
+
         $exists = [] !== $where && $this->exists($tableName, $where);
 
         if ($exists) {
@@ -214,6 +251,10 @@ class EntityRepository implements EntityRepositoryInterface, ResetInterface
      */
     public function addOrUpdateChildNode(array $data, string $tableName, array $types, string $parentId, array $where = []): void
     {
+        if ($this->dryRun) {
+            return;
+        }
+
         $exists = [] !== $where && $this->exists($tableName, $where);
 
         if ($exists) {
@@ -313,5 +354,6 @@ class EntityRepository implements EntityRepositoryInterface, ResetInterface
         $this->sequences = null;
         $this->tableExistsCache = [];
         $this->existsCache = [];
+        $this->dryRun = false;
     }
 }

--- a/PhpcrMigration/UserInterface/Command/MigratePhpcrCommand.php
+++ b/PhpcrMigration/UserInterface/Command/MigratePhpcrCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -19,12 +21,15 @@ use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Parser\NodeParse
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister\PersisterInterface;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Persister\PersisterPool;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Query\PostMigrationQueryInterface;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Repository\EntityRepositoryInterface;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Service\DryRunCollector;
 use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Session\SessionManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -32,6 +37,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class MigratePhpcrCommand extends Command
 {
     private const BATCH_SIZE = 1000;
+
+    private const LIVE_SUFFIX = '_live';
 
     /**
      * Document types that must be loaded in full upfront for ordering reasons.
@@ -42,6 +49,8 @@ class MigratePhpcrCommand extends Command
      */
     private const FULL_LOAD_TYPES = ['page', 'snippet_area'];
 
+    private bool $isDryRun = false;
+
     /**
      * @param iterable<PostMigrationQueryInterface> $postMigrationQueries
      */
@@ -51,6 +60,9 @@ class MigratePhpcrCommand extends Command
         private readonly PersisterPool $persisterPool,
         private readonly iterable $postMigrationQueries,
         private readonly Connection $connection,
+        private readonly EntityRepositoryInterface $entityRepository,
+        private readonly DryRunCollector $dryRunCollector,
+        private readonly string $projectDir,
     ) {
         parent::__construct();
     }
@@ -67,10 +79,30 @@ class MigratePhpcrCommand extends Command
             InputArgument::OPTIONAL,
             \sprintf('The document type(s) to migrate. Available: %s', \implode(', ', $types)),
         );
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'Run the migration without writing to the target database. Collects errors into a JSON report.',
+        );
+        $this->addOption(
+            'report',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Override the JSON report path (only used with --dry-run). Default: var/phpcr-migration/dry-run-YYYYMMDD-HHMMSS.json',
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new SymfonyStyle($input, $output);
+        $this->isDryRun = (bool) $input->getOption('dry-run');
+
+        if ($this->isDryRun) {
+            $this->entityRepository->setDryRun(true);
+            $io->note('Running in dry-run mode. No data will be written to the target database.');
+        }
+
         $session = $this->sessionManager->getDefaultSession();
         $liveSession = $this->sessionManager->getLiveSession();
 
@@ -80,7 +112,6 @@ class MigratePhpcrCommand extends Command
             ? \array_map(fn (string $type) => $this->persisterPool->getPersister($type), \explode(',', $documentTypesArg))
             : $this->persisterPool->getPersisters();
 
-        $io = new SymfonyStyle($input, $output);
         foreach ($persisters as $persister) {
             $documentType = $persister::getType();
             $io->title('Migrating ' . $documentType . ' documents');
@@ -91,6 +122,9 @@ class MigratePhpcrCommand extends Command
             /** @var SessionInterface $currentSession */
             foreach ($sessions as $currentSession) {
                 $sessionName = $currentSession->getWorkspace()->getName();
+                $isLive = \str_ends_with($sessionName, self::LIVE_SUFFIX);
+                $workspaceKey = $isLive ? \substr($sessionName, 0, -\strlen(self::LIVE_SUFFIX)) : $sessionName;
+
                 $io->section('Migrating ' . $documentType . ' documents in ' . $sessionName);
 
                 $queryManager = $currentSession->getWorkspace()->getQueryManager();
@@ -109,12 +143,11 @@ class MigratePhpcrCommand extends Command
                     $progressBar = $io->createProgressBar(\count($nodes));
                     $progressBar->setFormat(ProgressBar::FORMAT_DEBUG);
                     foreach ($nodes as $node) {
-                        $this->persistNode($node, $persister, $sessionName);
+                        $this->processNode($node, $persister, $isLive, $workspaceKey);
                         $progressBar->advance();
                     }
                 } else {
                     // Flat document types (articles, snippets, custom_urls) use batched fetching.
-                    $isLive = \str_ends_with($sessionName, '_live');
                     $progressBar = $io->createProgressBar();
                     $progressBar->setFormat(ProgressBar::FORMAT_DEBUG);
                     $lastPath = null;
@@ -137,7 +170,7 @@ class MigratePhpcrCommand extends Command
                         }
 
                         foreach ($batch as $node) {
-                            $this->persistNode($node, $persister, $sessionName);
+                            $this->processNode($node, $persister, $isLive, $workspaceKey);
                             $progressBar->advance();
                         }
 
@@ -156,6 +189,19 @@ class MigratePhpcrCommand extends Command
             }
         }
 
+        if ($this->isDryRun) {
+            $io->section('Post-migration queries');
+            $io->writeln('Skipped in dry-run mode.');
+            $io->newLine();
+
+            $reportPath = $this->resolveReportPath($input);
+            $this->writeReport($this->dryRunCollector->toArray(), $reportPath);
+            $this->dryRunCollector->printSummary($io);
+            $io->writeln(\sprintf('Report written to: %s', $reportPath));
+
+            return Command::SUCCESS;
+        }
+
         foreach ($this->postMigrationQueries as $query) {
             $query->execute($this->connection);
         }
@@ -165,7 +211,65 @@ class MigratePhpcrCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function persistNode(NodeInterface $node, PersisterInterface $persister, string $sessionName): void
+    private function processNode(
+        NodeInterface $node,
+        PersisterInterface $persister,
+        bool $isLive,
+        string $workspaceKey,
+    ): void {
+        $documentType = $persister::getType();
+
+        try {
+            $this->persistNode($node, $persister, $isLive);
+        } catch (\Throwable $e) {
+            if (!$this->isDryRun) {
+                throw $e;
+            }
+
+            $this->dryRunCollector->record($e, [
+                'documentType' => $documentType,
+                'workspace' => $workspaceKey,
+                'uuid' => $node->getIdentifier(),
+                'path' => $node->getPath(),
+            ]);
+        }
+
+        if ($this->isDryRun) {
+            $this->dryRunCollector->recordProcessed($documentType, $workspaceKey);
+        }
+    }
+
+    private function resolveReportPath(InputInterface $input): string
+    {
+        /** @var string|null $reportOption */
+        $reportOption = $input->getOption('report');
+        if (null !== $reportOption && '' !== $reportOption) {
+            return $reportOption;
+        }
+
+        $timestamp = (new \DateTimeImmutable())->format('Ymd-His');
+
+        return $this->projectDir . '/var/phpcr-migration/dry-run-' . $timestamp . '.json';
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function writeReport(array $payload, string $path): void
+    {
+        $directory = \dirname($path);
+        if (!\is_dir($directory) && !\mkdir($directory, 0755, true) && !\is_dir($directory)) {
+            throw new \RuntimeException(\sprintf('Could not create report directory "%s".', $directory));
+        }
+
+        $json = \json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+
+        if (false === \file_put_contents($path, $json)) {
+            throw new \RuntimeException(\sprintf('Could not write dry-run report to "%s".', $path));
+        }
+    }
+
+    private function persistNode(NodeInterface $node, PersisterInterface $persister, bool $isLive): void
     {
         $documents = $this->nodeParser->parse($node, $persister::getType());
 
@@ -173,16 +277,10 @@ class MigratePhpcrCommand extends Command
         if ($this->isListOfDocuments($documents)) {
             /** @var array<string, mixed> $document */
             foreach ($documents as $document) {
-                $persister->persist(
-                    document: $document,
-                    isLive: \str_ends_with($sessionName, '_live'),
-                );
+                $persister->persist(document: $document, isLive: $isLive);
             }
         } else {
-            $persister->persist(
-                document: $documents,
-                isLive: \str_ends_with($sessionName, '_live'),
-            );
+            $persister->persist(document: $documents, isLive: $isLive);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,30 @@ php bin/adminconsole sulu:phpcr-migration:migrate snippet
 
 Allowed types are: `snippet`, `page`, `article`
 
+### Dry-run mode
+
+Preview a migration without writing anything to the target database:
+
+```shell
+php bin/adminconsole sulu:phpcr-migration:migrate --dry-run
+```
+
+This executes the full parse and persist pipeline against your real PHPCR
+content, but every database write is intercepted in-memory. The command
+collects every exception (one per document or document/locale pair),
+continues past failures, and at the end prints a grouped summary plus a
+JSON report you can hand off for data cleanup.
+
+Default report path: `var/phpcr-migration/dry-run-YYYYMMDD-HHMMSS.json`.
+Override it with `--report=/path/to/report.json`.
+
+**Limitations.** Dry-run catches PHP-level validation errors (title/slug
+length, missing webspace or parent, missing shadow template, etc.) but
+does **not** catch database-level issues such as foreign-key violations,
+unique-key collisions between two rows that would be written in the same
+run, column truncation, or NOT NULL violations on columns populated only
+by database defaults. Post-migration queries (permission contexts, access
+controls, automation tasks) are skipped in dry-run mode.
 
 ## 🛠️&nbsp; Development
 

--- a/Resources/config/command.xml
+++ b/Resources/config/command.xml
@@ -11,6 +11,9 @@
             <argument type="service" id="sulu_phpcr_migration.persister_pool"/>
             <argument type="tagged_iterator" tag="sulu_phpcr_migration.post_migration_query"/>
             <argument type="service" id="doctrine.dbal.default_connection"/>
+            <argument type="service" id="sulu_phpcr_migration.entity_repository"/>
+            <argument type="service" id="sulu_phpcr_migration.dry_run_collector"/>
+            <argument>%kernel.project_dir%</argument>
 
             <tag name="console.command"/>
         </service>

--- a/Resources/config/repository.xml
+++ b/Resources/config/repository.xml
@@ -4,6 +4,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Command -->
+        <service id="sulu_phpcr_migration.dry_run_collector"
+                 class="Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Service\DryRunCollector"/>
+
         <service id="sulu_phpcr_migration.entity_repository"
                  class="Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Infrastructure\Repository\EntityRepository">
             <argument type="service" id="sulu_phpcr_migration.target_connection"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

A new `--dry-run` flag runs the full parse and persist pipeline without writing anything to the target database. All writes are intercepted at the repository layer and errors are collected per document. At the end of the run a structured JSON report is written to disk and a summary is printed to the console.

#### Why?

Running a migration against a production database without a preview step is risky. Dry run mode lets operators validate their PHPCR content against the full migration logic before committing any changes.

#### Example Usage

```php
// Preview the migration without writing to the database
php bin/adminconsole sulu:phpcr-migration:migrate --dry-run

// Write the error report to a custom path
php bin/adminconsole sulu:phpcr-migration:migrate --dry-run --report=/tmp/migration-preview.json
```
