### PR TITLE
Add direct doctrine/orm constraint to fix lowest dependency CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
+        "doctrine/orm": "^2.17.3 || ^3.3",
         "jackalope/jackalope-doctrine-dbal": "^2.0",
         "jackalope/jackalope-jackrabbit": "^2.0",
         "sulu/sulu": "^3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The composer.json now declares doctrine/orm as a direct requirement with the constraint ^2.17.3 || ^3.3, matching the constraint used by sulu/sulu. No other files change.

#### Why?

The lowest dependency CI job started failing on 19 May after packagist added two new security advisories that block sulu/sulu 3.0.0 through 3.0.5. Composer therefore picked sulu/sulu 3.0.6, which exposes the disjunctive doctrine/orm constraint only as a transitive dependency. In that situation composer does not select the lowest version across the disjunction and locks doctrine/orm 3.3.0 together with gedmo/doctrine-extensions v3.11.0, which produces a fatal signature mismatch in NestedTreeRepository::__call. Declaring doctrine/orm directly makes composer pick orm 2.17.3 with the matching gedmo v3.8.0.