### PR TITLE
Fix block properties named "length" and snippet template key detection

### DIFF
--- a/PhpcrMigration/Application/Detector/FormMetadataFieldTypeDetector.php
+++ b/PhpcrMigration/Application/Detector/FormMetadataFieldTypeDetector.php
@@ -95,9 +95,9 @@ class FormMetadataFieldTypeDetector implements FieldTypeDetectorInterface
     }
 
     /**
-     * Sulu pages, articles and snippets store their template under `i18n:{locale}-template`.
-     * Document types that keep the template on a non-localized property are not supported here:
-     * `getType()` returns null for them and the property falls back to JSON decoding.
+     * Pages and articles store their template under `i18n:{locale}-template`, snippets keep a
+     * single unlocalized `template` property. Both are read; for any other shape `getType()`
+     * returns null and the property falls back to JSON decoding.
      */
     private function getTemplateKey(NodeInterface $node, string $locale): ?string
     {
@@ -111,15 +111,19 @@ class FormMetadataFieldTypeDetector implements FieldTypeDetectorInterface
             return $this->cachedTemplateKeysForNode[$locale];
         }
 
-        $templateProperty = LocaleExtractor::I18N_PREFIX . $locale . '-template';
+        foreach ([LocaleExtractor::I18N_PREFIX . $locale . '-template', 'template'] as $templateProperty) {
+            if (!$node->hasProperty($templateProperty)) {
+                continue;
+            }
 
-        if (!$node->hasProperty($templateProperty)) {
-            return $this->cachedTemplateKeysForNode[$locale] = null;
+            $value = $node->getPropertyValue($templateProperty);
+
+            if (\is_string($value) && '' !== $value) {
+                return $this->cachedTemplateKeysForNode[$locale] = $value;
+            }
         }
 
-        $value = $node->getPropertyValue($templateProperty);
-
-        return $this->cachedTemplateKeysForNode[$locale] = \is_string($value) && '' !== $value ? $value : null;
+        return $this->cachedTemplateKeysForNode[$locale] = null;
     }
 
     /**

--- a/PhpcrMigration/Application/Parser/PropertyNodeParser.php
+++ b/PhpcrMigration/Application/Parser/PropertyNodeParser.php
@@ -240,7 +240,6 @@ class PropertyNodeParser implements NodeParserInterface
         $isImageMap = false;
         foreach ($blocks as $index => $item) {
             if ('length' === $index) {
-                /** @var int $maxLength */
                 $maxLength = $item;
             }
 
@@ -253,7 +252,8 @@ class PropertyNodeParser implements NodeParserInterface
             }
         }
 
-        if (null !== $maxLength) {
+        // Only the PHPCR Long counter is an int; a block's own property named "length" never is.
+        if (\is_int($maxLength)) {
             // remove length property
             unset($blocks['length']);
 

--- a/Tests/Unit/PhpcrMigration/Application/Detector/FormMetadataFieldTypeDetectorSnippetTemplateTest.php
+++ b/Tests/Unit/PhpcrMigration/Application/Detector/FormMetadataFieldTypeDetectorSnippetTemplateTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PhpcrMigrationBundle\Tests\Unit\PhpcrMigration\Application\Detector;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Detector\FormMetadataFieldTypeDetector;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Extractor\LocaleExtractor;
+
+#[CoversClass(FormMetadataFieldTypeDetector::class)]
+final class FormMetadataFieldTypeDetectorSnippetTemplateTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testDetectsFieldTypeForSnippetWithUnlocalizedTemplateProperty(): void
+    {
+        $date = new FieldMetadata('date');
+        $date->setType('date');
+
+        $form = new FormMetadata();
+        $form->setKey('performance');
+        $form->setItems(['date' => $date]);
+
+        $typedForm = new TypedFormMetadata();
+        $typedForm->addForm('performance', $form);
+
+        $metadataProvider = $this->prophesize(MetadataProviderInterface::class);
+        $metadataProvider->getMetadata('snippet', Argument::any(), Argument::any())->willReturn($typedForm);
+
+        $detector = new FormMetadataFieldTypeDetector(
+            $metadataProvider->reveal(),
+            new LocaleExtractor(),
+            ['snippet' => ['performance' => []]],
+        );
+
+        self::assertSame(
+            'date',
+            $detector->getType('snippet', 'i18n:de-date', $this->createSnippetNode()),
+            'Snippets keep a single unlocalized "template" property; without reading it no field type is known.',
+        );
+    }
+
+    private function createSnippetNode(): NodeInterface
+    {
+        $properties = [];
+        $values = [
+            'i18n:de-title' => 'Konzert',
+            'i18n:de-created' => '2026-08-23',
+            'i18n:de-date' => '2027-02-02',
+            'template' => 'performance',
+        ];
+
+        foreach ($values as $name => $value) {
+            $property = $this->prophesize(PropertyInterface::class);
+            $property->getName()->willReturn($name);
+            $property->getValue()->willReturn($value);
+            $properties[$name] = $property->reveal();
+        }
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getIdentifier()->willReturn('9f1d5a1c-0000-4000-8000-000000000000');
+        $node->getProperties()->willReturn($properties);
+        $node->getProperties(Argument::type('string'))->will(
+            function(array $args) use ($properties) {
+                $suffix = \substr((string) $args[0], \strlen('i18n:*'));
+
+                return \array_filter(
+                    $properties,
+                    static fn (string $name) => \str_ends_with($name, $suffix),
+                    \ARRAY_FILTER_USE_KEY,
+                );
+            }
+        );
+        $node->hasProperty(Argument::any())->will(
+            fn (array $args) => \array_key_exists($args[0], $properties)
+        );
+        $node->getPropertyValue(Argument::any())->will(
+            fn (array $args) => $properties[$args[0]]->getValue()
+        );
+
+        return $node->reveal();
+    }
+}

--- a/Tests/Unit/PhpcrMigration/Application/Parser/PropertyNodeParserBlockLengthTest.php
+++ b/Tests/Unit/PhpcrMigration/Application/Parser/PropertyNodeParserBlockLengthTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PhpcrMigrationBundle\Tests\Unit\PhpcrMigration\Application\Parser;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Detector\FieldTypeDetectorInterface;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Extractor\LocaleExtractor;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Parser\PropertyNodeParser;
+use Sulu\Bundle\PhpcrMigrationBundle\PhpcrMigration\Application\Resolver\PropertyValueResolver;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+#[CoversClass(PropertyNodeParser::class)]
+final class PropertyNodeParserBlockLengthTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testKeepsBlocksWhenTemplatePropertyIsNamedLength(): void
+    {
+        $properties = [
+            'i18n:de-title' => 'Konzerte',
+            'i18n:de-template' => 'composition',
+            'i18n:de-music-length' => 2,
+            'i18n:de-music-title#0' => 'Erster Satz',
+            'i18n:de-music-length#0' => '0:45',
+            'i18n:de-music-title#1' => 'Zweiter Satz',
+            'i18n:de-music-length#1' => '1:12',
+        ];
+
+        $music = $this->localizedProperty($this->parse($properties), 'music');
+
+        self::assertCount(2, $music, 'A block property named "length" is not the counter and must not trim.');
+        self::assertSame(['title' => 'Erster Satz', 'length' => '0:45'], $music[0]);
+        self::assertSame(['title' => 'Zweiter Satz', 'length' => '1:12'], $music[1]);
+    }
+
+    public function testStillTrimsBlocksToTheCounter(): void
+    {
+        $properties = [
+            'i18n:de-title' => 'Konzerte',
+            'i18n:de-template' => 'composition',
+            'i18n:de-blocks-length' => 1,
+            'i18n:de-blocks-title#0' => 'Bleibt',
+            'i18n:de-blocks-title#1' => 'Wurde geloescht',
+        ];
+
+        $blocks = $this->localizedProperty($this->parse($properties), 'blocks');
+
+        self::assertCount(1, $blocks, 'PHPCR leaves deleted blocks behind; only the first "length" entries belong to the document.');
+        self::assertSame(['title' => 'Bleibt'], $blocks[0]);
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function localizedProperty(array $document, string $name): array
+    {
+        $localizations = $document['localizations'] ?? null;
+        self::assertIsArray($localizations);
+
+        $german = $localizations['de'] ?? null;
+        self::assertIsArray($german);
+
+        $value = $german[$name] ?? null;
+        self::assertIsArray($value);
+
+        /** @var array<int, array<string, mixed>> $value */
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>
+     */
+    private function parse(array $properties): array
+    {
+        $propertyObjects = [];
+        foreach ($properties as $name => $value) {
+            $property = $this->prophesize(PropertyInterface::class);
+            $property->getName()->willReturn($name);
+            $property->getValue()->willReturn($value);
+            $propertyObjects[$name] = $property->reveal();
+        }
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getIdentifier()->willReturn('4c0b1e5a-0000-4000-8000-000000000000');
+        $node->getProperties()->willReturn($propertyObjects);
+
+        // The locale is derived from the `-title`/`-template`/`-created` properties.
+        $node->getProperties(Argument::type('string'))->will(
+            function(array $args) use ($propertyObjects) {
+                $suffix = \substr((string) $args[0], \strlen('i18n:*'));
+
+                return \array_filter(
+                    $propertyObjects,
+                    static fn (string $name) => \str_ends_with($name, $suffix),
+                    \ARRAY_FILTER_USE_KEY,
+                );
+            }
+        );
+
+        $detector = $this->prophesize(FieldTypeDetectorInterface::class);
+        $detector->getType(Argument::cetera())->willReturn(null);
+
+        $parser = new PropertyNodeParser(
+            PropertyAccess::createPropertyAccessor(),
+            new LocaleExtractor(),
+            new PropertyValueResolver($detector->reveal()),
+        );
+
+        return $parser->parse($node->reveal(), 'page');
+    }
+}


### PR DESCRIPTION
Two bugs found while migrating a real 2.6 project (a small Sulu site with pages,
snippets and three locales). Either one stops the migration from producing a
usable result, and the second one does so silently.

### 1. A template property named `length` is mistaken for the block counter

PHPCR stores the number of blocks as `<block>-length` and a block's own
properties as `<block>-<property>#<index>`. A template that declares a property
called `length` — a track length such as `0:45` — therefore writes
`<block>-length#0`, which the parser maps into the very same array slot as the
counter.

`trimBlocksToLengths()` handed whatever sat in that slot to `array_slice()`:

```
array_slice(): Argument #3 ($length) must be of type ?int, string given
```

The migration aborts on the first affected node, and the project cannot be
migrated at all. The counter is always an integer and a template property never
is, so the type is enough to tell them apart.

### 2. Snippets keep their template key unlocalized, so no field type is detected

`getTemplateKey()` only looked for `i18n:{locale}-template`. Pages and articles
store it that way, snippets store a single unlocalized `template` property — the
docblock even stated the assumption that all three are localized.

Without a template key there is no field type for *any* snippet property, so
`PropertyValueResolver` skips its date formatting and the raw value is
JSON-encoded as it comes out of PHPCR:

```json
{"date": "2027-02-02 21:49:24.000000", "timezone_type": 1, "timezone": "+01:00"}
```

instead of the `"2027-02-02"` string Sulu 3's date resolver expects. Nothing
fails, nothing is logged — the value is simply unusable. In our case a list of
concert dates rendered in essentially random order, because every date parsed as
"now". That took a while to trace back here.

### Tests

Two unit tests, each failing before the respective fix with the exact error seen
in production. `composer lint` and the full functional suite (100 tests,
including the JSON baselines) pass.

The fixes are independent; happy to split them into two PRs if you prefer.
